### PR TITLE
Fixed non-existing preview scene errors when not in Studio Mode

### DIFF
--- a/scene_execute_command.lua
+++ b/scene_execute_command.lua
@@ -136,6 +136,10 @@ function handle_scene_change()
     -- Live
 	local scene = obs.obs_frontend_get_current_scene()
 	local scene_name = obs.obs_source_get_name(scene)
+	if (scene_name == nil) then
+		return
+	end
+	
 	local scene_enabled = obs.obs_data_get_bool(settings, "scene_enabled_" .. scene_name)
 	local last_scene = StoreLive()
 	
@@ -185,6 +189,10 @@ function handle_scene_change_Preview()
     -- Preview
 	local scene = obs.obs_frontend_get_current_preview_scene()
 	local scene_name = obs.obs_source_get_name(scene)
+	if (scene_name == nil) then
+		return
+	end
+	
 	local scene_enabled = obs.obs_data_get_bool(settings, "Preview_scene_enabled_" .. scene_name)
 	local preview_last_scene = StorePreview()
 	


### PR DESCRIPTION
When Studio Mode is disabled there might not always be a preview scene name. Lua raises errors when trying to combining strings with `nil` strings:
```Failed to call frontend_event_callback for frontend API: /.../scene_execute_command.lua:188: attempt to concatenate local 'scene_name' (a nil value)```

I applied the fix to simply check if this variable is `nil`. It works for me, but I'm not experienced with OBS lua scripts so please double check. 